### PR TITLE
check version with VERSION method, not import

### DIFF
--- a/xt/meta-lint.t
+++ b/xt/meta-lint.t
@@ -11,9 +11,8 @@ use Test::More;
 eval {
   #require Test::MinimumVersion::Fast;
   require Parse::CPAN::Meta;
-  Parse::CPAN::Meta->import();
   require CPAN::Meta::Validator;
-  CPAN::Meta::Validator->import(2.15);
+  CPAN::Meta::Validator->VERSION(2.15);
 };
 if ($@) {
   plan skip_all => "CPAN::Meta::Validator version 2.15 required for testing META files";


### PR DESCRIPTION
Trying to use import to check a version would sometimes check the version, but only if Exporter was being used. Otherwise, the version would throw an error or just be ignored. The correct way to check a version is using the VERSION method.