### PR TITLE
Replace AddPhonebookEntry by SetPhonebookEntry

### DIFF
--- a/lib/Net/Fritz/PhonebookEntry.pm
+++ b/lib/Net/Fritz/PhonebookEntry.pm
@@ -3,6 +3,7 @@ use strict;
 use Carp qw(croak);
 use Moo 2;
 use Filter::signatures;
+use XML::Simple qw(:strict);
 use feature 'signatures';
 no warnings 'experimental::signatures';
 
@@ -340,9 +341,14 @@ sub delete( $self, %options ) {
 }
 
 sub save( $self ) {
-    my $payload = $self->build_structure;
+    my $payload = XMLout(
+        $self->build_structure,
+        RootName => 'contact',
+        XMLDecl  => 1,
+        KeyAttr  => [],
+    );
 
-    $self->phonebook->service->call('AddPhonebookEntry',
+    $self->phonebook->service->call('SetPhonebookEntry',
         NewPhonebookID => $self->phonebook->id,
         NewPhonebookEntryID => $self->uniqueid,
         NewPhonebookEntryData => $payload,


### PR DESCRIPTION
This pull request replaces `AddPhonebookEntry` by `SetPhonebookEntry` in [Net::Fritz::PhonebookEntry->save](https://github.com/Corion/Net-Fritz-Phonebook/blob/bec62c2d1d0c03f34bf353bdd9a624dcd73cbaf5/lib/Net/Fritz/PhonebookEntry.pm#L342).

Fritz!Boxes handle Unicode characters properly if `XMLDecl => 1` is passed to `XMLout`. You could specify `XMLDecl => '<?xml version="1.0" encoding="UTF-8"?>'` instead, but it's not needed.

This PR fixes #9 but does neither update nor replace [Net::Fritz::PhonebookEntry->create](https://github.com/Corion/Net-Fritz-Phonebook/blob/bec62c2d1d0c03f34bf353bdd9a624dcd73cbaf5/lib/Net/Fritz/PhonebookEntry.pm#L267). 