### PR TITLE
Update hyperlinks to AVM's documentation

### DIFF
--- a/lib/Net/Fritz/Phonebook.pm
+++ b/lib/Net/Fritz/Phonebook.pm
@@ -298,7 +298,7 @@ sub reload( $self ) {
 
 =head1 SEE ALSO
 
-L<https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/X_contactSCPD.pdf>
+L<https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/x_contactSCPD.pdf>
 
 =cut
 

--- a/lib/Net/Fritz/PhonebookEntry/Mail.pm
+++ b/lib/Net/Fritz/PhonebookEntry/Mail.pm
@@ -43,7 +43,7 @@ sub build_structure( $self ) {
 
 =head1 SEE ALSO
 
-L<https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/X_contactSCPD.pdf>
+L<https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/x_contactSCPD.pdf>
 
 =cut
 


### PR DESCRIPTION
This pull request updates two links to AVM's [x_contactSCPD.pdf](https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/x_contactSCPD.pdf) document. The document's filename starts with a lowercase `x`.